### PR TITLE
Adding the lowercase module name scheme

### DIFF
--- a/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
+++ b/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
@@ -1,0 +1,62 @@
+##
+# Copyright 2013-2017 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Implementation of (default) EasyBuild module naming scheme.
+:author: Kenneth Hoste (Ghent University)
+:author: Guilherme Peretti-Pezzi (CSCS)
+"""
+
+import os
+import re
+
+from easybuild.tools.module_naming_scheme import ModuleNamingScheme
+from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
+
+class LowercaseModuleNamingScheme(ModuleNamingScheme):
+    """Class implementing a lowercase module naming scheme."""
+
+    REQUIRED_KEYS = ['name', 'version', 'versionsuffix', 'toolchain']
+
+    def det_full_module_name(self, ec):
+        """
+        Determine full module name from given easyconfig, according to the EasyBuild module naming scheme.
+        :param ec: dict-like object with easyconfig parameter values (e.g. 'name', 'version', etc.)
+        :return: string with full module name <name>/<installversion>, e.g.: 'gzip/1.5-goolf-1.4.10'
+        """
+        return os.path.join(ec['name'], det_full_ec_version(ec)).lower()
+
+    def is_short_modname_for(self, short_modname, name):
+        """
+        Determine whether the specified (short) module name is a module for software with the specified name.
+        Default implementation checks via a strict regex pattern, and assumes short module names are of the form:
+            <name>/<version>[-<toolchain>]
+        """
+        modname_regex = re.compile('^%s(/\S+)?$' % re.escape(name.lower()))
+        res = bool(modname_regex.match(short_modname))
+
+        self.log.debug("Checking whether '%s' is a module name for software with name '%s' via regex %s: %s",
+                       short_modname, name, modname_regex.pattern, res)
+
+        return res


### PR DESCRIPTION
We got a request from one of our customers to enable the module names always as lowercases. 
This is the implementation of this feature. We would like to contribute this feature back.